### PR TITLE
Change any to unknown

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -33,7 +33,7 @@ function isNull(payload) {
  * Returns whether the payload is a plain JavaScript object (excluding special classes or objects with other prototypes)
  *
  * @param {*} payload
- * @returns {payload is {[key: string]: any}}
+ * @returns {payload is {[key: string]: unknown}}
  */
 function isPlainObject(payload) {
     if (getType(payload) !== 'Object')
@@ -44,16 +44,16 @@ function isPlainObject(payload) {
  * Returns whether the payload is a plain JavaScript object (excluding special classes or objects with other prototypes)
  *
  * @param {*} payload
- * @returns {payload is {[key: string]: any}}
+ * @returns {payload is {[key: string]: unknown}}
  */
 function isObject(payload) {
     return isPlainObject(payload);
 }
 /**
- * Returns whether the payload is an any kind of object (including special classes or objects with different prototypes)
+ * Returns whether the payload is an unknown kind of object (including special classes or objects with different prototypes)
  *
  * @param {*} payload
- * @returns {payload is {[key: string]: any}}
+ * @returns {payload is {[key: string]: unknown}}
  */
 function isAnyObject(payload) {
     return getType(payload) === 'Object';
@@ -61,7 +61,7 @@ function isAnyObject(payload) {
 /**
  * Returns whether the payload is an object like a type passed in < >
  *
- * Usage: isObjectLike<{id: any}>(payload) // will make sure it's an object and has an `id` prop.
+ * Usage: isObjectLike<{id: unknown}>(payload) // will make sure it's an object and has an `id` prop.
  *
  * @template T this must be passed in < >
  * @param {*} payload

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -29,7 +29,7 @@ function isNull(payload) {
  * Returns whether the payload is a plain JavaScript object (excluding special classes or objects with other prototypes)
  *
  * @param {*} payload
- * @returns {payload is {[key: string]: any}}
+ * @returns {payload is {[key: string]: unknown}}
  */
 function isPlainObject(payload) {
     if (getType(payload) !== 'Object')
@@ -40,16 +40,16 @@ function isPlainObject(payload) {
  * Returns whether the payload is a plain JavaScript object (excluding special classes or objects with other prototypes)
  *
  * @param {*} payload
- * @returns {payload is {[key: string]: any}}
+ * @returns {payload is {[key: string]: unknown}}
  */
 function isObject(payload) {
     return isPlainObject(payload);
 }
 /**
- * Returns whether the payload is an any kind of object (including special classes or objects with different prototypes)
+ * Returns whether the payload is an unknown kind of object (including special classes or objects with different prototypes)
  *
  * @param {*} payload
- * @returns {payload is {[key: string]: any}}
+ * @returns {payload is {[key: string]: unknown}}
  */
 function isAnyObject(payload) {
     return getType(payload) === 'Object';
@@ -57,7 +57,7 @@ function isAnyObject(payload) {
 /**
  * Returns whether the payload is an object like a type passed in < >
  *
- * Usage: isObjectLike<{id: any}>(payload) // will make sure it's an object and has an `id` prop.
+ * Usage: isObjectLike<{id: unknown}>(payload) // will make sure it's an object and has an `id` prop.
  *
  * @template T this must be passed in < >
  * @param {*} payload

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  * @param {*} payload
  * @returns {string}
  */
-export function getType (payload: any): string {
+export function getType (payload: unknown): string {
   return Object.prototype.toString.call(payload).slice(8, -1)
 }
 
@@ -14,7 +14,7 @@ export function getType (payload: any): string {
  * @param {*} payload
  * @returns {payload is undefined}
  */
-export function isUndefined (payload: any): payload is undefined {
+export function isUndefined (payload: unknown): payload is undefined {
   return getType(payload) === 'Undefined'
 }
 
@@ -24,7 +24,7 @@ export function isUndefined (payload: any): payload is undefined {
  * @param {*} payload
  * @returns {payload is null}
  */
-export function isNull (payload: any): payload is null {
+export function isNull (payload: unknown): payload is null {
   return getType(payload) === 'Null'
 }
 
@@ -32,9 +32,9 @@ export function isNull (payload: any): payload is null {
  * Returns whether the payload is a plain JavaScript object (excluding special classes or objects with other prototypes)
  *
  * @param {*} payload
- * @returns {payload is {[key: string]: any}}
+ * @returns {payload is {[key: string]: unknown}}
  */
-export function isPlainObject (payload: any): payload is { [key: string]: any } {
+export function isPlainObject (payload: unknown): payload is { [key: string]: unknown } {
   if (getType(payload) !== 'Object') return false
   return payload.constructor === Object && Object.getPrototypeOf(payload) === Object.prototype
 }
@@ -43,32 +43,32 @@ export function isPlainObject (payload: any): payload is { [key: string]: any } 
  * Returns whether the payload is a plain JavaScript object (excluding special classes or objects with other prototypes)
  *
  * @param {*} payload
- * @returns {payload is {[key: string]: any}}
+ * @returns {payload is {[key: string]: unknown}}
  */
-export function isObject (payload: any): payload is { [key: string]: any } {
+export function isObject (payload: unknown): payload is { [key: string]: unknown } {
   return isPlainObject(payload)
 }
 
 /**
- * Returns whether the payload is an any kind of object (including special classes or objects with different prototypes)
+ * Returns whether the payload is an unknown kind of object (including special classes or objects with different prototypes)
  *
  * @param {*} payload
- * @returns {payload is {[key: string]: any}}
+ * @returns {payload is {[key: string]: unknown}}
  */
-export function isAnyObject (payload: any): payload is { [key: string]: any } {
+export function isAnyObject (payload: unknown): payload is { [key: string]: unknown } {
   return getType(payload) === 'Object'
 }
 
 /**
  * Returns whether the payload is an object like a type passed in < >
  *
- * Usage: isObjectLike<{id: any}>(payload) // will make sure it's an object and has an `id` prop.
+ * Usage: isObjectLike<{id: unknown}>(payload) // will make sure it's an object and has an `id` prop.
  *
  * @template T this must be passed in < >
  * @param {*} payload
  * @returns {payload is T}
  */
-export function isObjectLike<T extends object> (payload: any): payload is T {
+export function isObjectLike<T extends object> (payload: unknown): payload is T {
   return isAnyObject(payload)
 }
 
@@ -78,7 +78,7 @@ export function isObjectLike<T extends object> (payload: any): payload is T {
  * @param {*} payload
  * @returns {payload is Function}
  */
-export function isFunction (payload: any): payload is Function {
+export function isFunction (payload: unknown): payload is Function {
   return getType(payload) === 'Function'
 }
 
@@ -88,7 +88,7 @@ export function isFunction (payload: any): payload is Function {
  * @param {*} payload
  * @returns {payload is undefined}
  */
-export function isArray (payload: any): payload is any[] {
+export function isArray (payload: unknown): payload is unknown[] {
   return getType(payload) === 'Array'
 }
 
@@ -98,7 +98,7 @@ export function isArray (payload: any): payload is any[] {
  * @param {*} payload
  * @returns {payload is string}
  */
-export function isString (payload: any): payload is string {
+export function isString (payload: unknown): payload is string {
   return getType(payload) === 'String'
 }
 
@@ -108,7 +108,7 @@ export function isString (payload: any): payload is string {
  * @param {*} payload
  * @returns {payload is string}
  */
-export function isFullString (payload: any): payload is string {
+export function isFullString (payload: unknown): payload is string {
   return isString(payload) && payload !== ''
 }
 
@@ -118,7 +118,7 @@ export function isFullString (payload: any): payload is string {
  * @param {*} payload
  * @returns {payload is string}
  */
-export function isEmptyString (payload: any): payload is string {
+export function isEmptyString (payload: unknown): payload is string {
   return payload === ''
 }
 
@@ -130,8 +130,8 @@ export function isEmptyString (payload: any): payload is string {
  * @param {*} payload
  * @returns {payload is number}
  */
-export function isNumber (payload: any): payload is number {
-  return getType(payload) === 'Number' && !isNaN(payload)
+export function isNumber (payload: unknown): payload is number {
+  return getType(payload) === 'Number' && !isNaN(payload as any)
 }
 
 /**
@@ -140,7 +140,7 @@ export function isNumber (payload: any): payload is number {
  * @param {*} payload
  * @returns {payload is boolean}
  */
-export function isBoolean (payload: any): payload is boolean {
+export function isBoolean (payload: unknown): payload is boolean {
   return getType(payload) === 'Boolean'
 }
 
@@ -150,7 +150,7 @@ export function isBoolean (payload: any): payload is boolean {
  * @param {*} payload
  * @returns {payload is RegExp}
  */
-export function isRegExp (payload: any): payload is RegExp {
+export function isRegExp (payload: unknown): payload is RegExp {
   return getType(payload) === 'RegExp'
 }
 
@@ -160,7 +160,7 @@ export function isRegExp (payload: any): payload is RegExp {
  * @param {*} payload
  * @returns {payload is Map}
  */
-export function isMap (payload: any): payload is Map<any, any> {
+export function isMap (payload: unknown): payload is Map<unknown, unknown> {
   return getType(payload) === 'Map'
 }
 
@@ -170,7 +170,7 @@ export function isMap (payload: any): payload is Map<any, any> {
  * @param {*} payload
  * @returns {payload is WeakMap}
  */
-export function isWeakMap (payload: any): payload is WeakMap<any, any> {
+export function isWeakMap (payload: unknown): payload is WeakMap<any, unknown> {
   return getType(payload) === 'WeakMap'
 }
 
@@ -180,7 +180,7 @@ export function isWeakMap (payload: any): payload is WeakMap<any, any> {
  * @param {*} payload
  * @returns {payload is Set}
  */
-export function isSet (payload: any): payload is Set<any> {
+export function isSet (payload: unknown): payload is Set<unknown> {
   return getType(payload) === 'Set'
 }
 
@@ -190,7 +190,7 @@ export function isSet (payload: any): payload is Set<any> {
  * @param {*} payload
  * @returns {payload is WeakSet}
  */
-export function isWeakSet (payload: any): payload is WeakSet<any> {
+export function isWeakSet (payload: unknown): payload is WeakSet<any> {
   return getType(payload) === 'WeakSet'
 }
 
@@ -200,7 +200,7 @@ export function isWeakSet (payload: any): payload is WeakSet<any> {
  * @param {*} payload
  * @returns {payload is symbol}
  */
-export function isSymbol (payload: any): payload is symbol {
+export function isSymbol (payload: unknown): payload is symbol {
   return getType(payload) === 'Symbol'
 }
 
@@ -210,8 +210,8 @@ export function isSymbol (payload: any): payload is symbol {
  * @param {*} payload
  * @returns {payload is Date}
  */
-export function isDate (payload: any): payload is Date {
-  return getType(payload) === 'Date' && !isNaN(payload)
+export function isDate (payload: unknown): payload is Date {
+  return getType(payload) === 'Date' && !isNaN(payload as any)
 }
 
 /**
@@ -220,7 +220,7 @@ export function isDate (payload: any): payload is Date {
  * @param {*} payload
  * @returns {payload is Blob}
  */
-export function isBlob (payload: any): payload is Blob {
+export function isBlob (payload: unknown): payload is Blob {
   return getType(payload) === 'Blob'
 }
 
@@ -230,7 +230,7 @@ export function isBlob (payload: any): payload is Blob {
  * @param {*} payload
  * @returns {payload is File}
  */
-export function isFile (payload: any): payload is File {
+export function isFile (payload: unknown): payload is File {
   return getType(payload) === 'File'
 }
 
@@ -240,7 +240,7 @@ export function isFile (payload: any): payload is File {
  * @param {*} payload
  * @returns {payload is Promise}
  */
-export function isPromise (payload: any): payload is Promise<any> {
+export function isPromise (payload: unknown): payload is Promise<unknown> {
   return getType(payload) === 'Promise'
 }
 
@@ -250,7 +250,7 @@ export function isPromise (payload: any): payload is Promise<any> {
  * @param {*} payload
  * @returns {payload is Error}
  */
-export function isError (payload: any): payload is Error {
+export function isError (payload: unknown): payload is Error {
   return getType(payload) === 'Error'
 }
 
@@ -261,7 +261,7 @@ export function isError (payload: any): payload is Error {
  * @returns {(payload is boolean | null | undefined | number | string | symbol)}
  */
 export function isPrimitive (
-  payload: any
+  payload: unknown
 ): payload is boolean | null | undefined | number | string | symbol {
   return (
     isBoolean(payload) ||
@@ -279,7 +279,7 @@ export function isPrimitive (
  * @param {*} payload
  * @returns {(payload is null | undefined)}
  */
-export function isNullOrUndefined (payload: any): payload is null | undefined {
+export function isNullOrUndefined (payload: unknown): payload is null | undefined {
   return isNull(payload) || isUndefined(payload)
 }
 
@@ -294,7 +294,7 @@ export function isNullOrUndefined (payload: any): payload is null | undefined {
  * @throws {TypeError} Will throw type error if type is an invalid type
  * @returns {payload is T}
  */
-export function isType<T extends Function> (payload: any, type: T): payload is T {
+export function isType<T extends Function> (payload: unknown, type: T): payload is T {
   if (!(type instanceof Function)) {
     throw new TypeError('Type must be a function')
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,93 +4,93 @@
  * @param {*} payload
  * @returns {string}
  */
-export declare function getType(payload: any): string;
+export declare function getType(payload: unknown): string;
 /**
  * Returns whether the payload is undefined
  *
  * @param {*} payload
  * @returns {payload is undefined}
  */
-export declare function isUndefined(payload: any): payload is undefined;
+export declare function isUndefined(payload: unknown): payload is undefined;
 /**
  * Returns whether the payload is null
  *
  * @param {*} payload
  * @returns {payload is null}
  */
-export declare function isNull(payload: any): payload is null;
+export declare function isNull(payload: unknown): payload is null;
 /**
  * Returns whether the payload is a plain JavaScript object (excluding special classes or objects with other prototypes)
  *
  * @param {*} payload
- * @returns {payload is {[key: string]: any}}
+ * @returns {payload is {[key: string]: unknown}}
  */
-export declare function isPlainObject(payload: any): payload is {
-    [key: string]: any;
+export declare function isPlainObject(payload: unknown): payload is {
+    [key: string]: unknown;
 };
 /**
  * Returns whether the payload is a plain JavaScript object (excluding special classes or objects with other prototypes)
  *
  * @param {*} payload
- * @returns {payload is {[key: string]: any}}
+ * @returns {payload is {[key: string]: unknown}}
  */
-export declare function isObject(payload: any): payload is {
-    [key: string]: any;
+export declare function isObject(payload: unknown): payload is {
+    [key: string]: unknown;
 };
 /**
- * Returns whether the payload is an any kind of object (including special classes or objects with different prototypes)
+ * Returns whether the payload is an unknown kind of object (including special classes or objects with different prototypes)
  *
  * @param {*} payload
- * @returns {payload is {[key: string]: any}}
+ * @returns {payload is {[key: string]: unknown}}
  */
-export declare function isAnyObject(payload: any): payload is {
-    [key: string]: any;
+export declare function isAnyObject(payload: unknown): payload is {
+    [key: string]: unknown;
 };
 /**
  * Returns whether the payload is an object like a type passed in < >
  *
- * Usage: isObjectLike<{id: any}>(payload) // will make sure it's an object and has an `id` prop.
+ * Usage: isObjectLike<{id: unknown}>(payload) // will make sure it's an object and has an `id` prop.
  *
  * @template T this must be passed in < >
  * @param {*} payload
  * @returns {payload is T}
  */
-export declare function isObjectLike<T extends object>(payload: any): payload is T;
+export declare function isObjectLike<T extends object>(payload: unknown): payload is T;
 /**
  * Returns whether the payload is a function
  *
  * @param {*} payload
  * @returns {payload is Function}
  */
-export declare function isFunction(payload: any): payload is Function;
+export declare function isFunction(payload: unknown): payload is Function;
 /**
  * Returns whether the payload is an array
  *
  * @param {*} payload
  * @returns {payload is undefined}
  */
-export declare function isArray(payload: any): payload is any[];
+export declare function isArray(payload: unknown): payload is unknown[];
 /**
  * Returns whether the payload is a string
  *
  * @param {*} payload
  * @returns {payload is string}
  */
-export declare function isString(payload: any): payload is string;
+export declare function isString(payload: unknown): payload is string;
 /**
  * Returns whether the payload is a string, BUT returns false for ''
  *
  * @param {*} payload
  * @returns {payload is string}
  */
-export declare function isFullString(payload: any): payload is string;
+export declare function isFullString(payload: unknown): payload is string;
 /**
  * Returns whether the payload is ''
  *
  * @param {*} payload
  * @returns {payload is string}
  */
-export declare function isEmptyString(payload: any): payload is string;
+export declare function isEmptyString(payload: unknown): payload is string;
 /**
  * Returns whether the payload is a number
  *
@@ -99,105 +99,105 @@ export declare function isEmptyString(payload: any): payload is string;
  * @param {*} payload
  * @returns {payload is number}
  */
-export declare function isNumber(payload: any): payload is number;
+export declare function isNumber(payload: unknown): payload is number;
 /**
  * Returns whether the payload is a boolean
  *
  * @param {*} payload
  * @returns {payload is boolean}
  */
-export declare function isBoolean(payload: any): payload is boolean;
+export declare function isBoolean(payload: unknown): payload is boolean;
 /**
  * Returns whether the payload is a regular expression (RegExp)
  *
  * @param {*} payload
  * @returns {payload is RegExp}
  */
-export declare function isRegExp(payload: any): payload is RegExp;
+export declare function isRegExp(payload: unknown): payload is RegExp;
 /**
  * Returns whether the payload is a Map
  *
  * @param {*} payload
  * @returns {payload is Map}
  */
-export declare function isMap(payload: any): payload is Map<any, any>;
+export declare function isMap(payload: unknown): payload is Map<unknown, unknown>;
 /**
  * Returns whether the payload is a WeakMap
  *
  * @param {*} payload
  * @returns {payload is WeakMap}
  */
-export declare function isWeakMap(payload: any): payload is WeakMap<any, any>;
+export declare function isWeakMap(payload: unknown): payload is WeakMap<any, unknown>;
 /**
  * Returns whether the payload is a Set
  *
  * @param {*} payload
  * @returns {payload is Set}
  */
-export declare function isSet(payload: any): payload is Set<any>;
+export declare function isSet(payload: unknown): payload is Set<unknown>;
 /**
  * Returns whether the payload is a WeakSet
  *
  * @param {*} payload
  * @returns {payload is WeakSet}
  */
-export declare function isWeakSet(payload: any): payload is WeakSet<any>;
+export declare function isWeakSet(payload: unknown): payload is WeakSet<any>;
 /**
  * Returns whether the payload is a Symbol
  *
  * @param {*} payload
  * @returns {payload is symbol}
  */
-export declare function isSymbol(payload: any): payload is symbol;
+export declare function isSymbol(payload: unknown): payload is symbol;
 /**
  * Returns whether the payload is a Date, and that the date is valid
  *
  * @param {*} payload
  * @returns {payload is Date}
  */
-export declare function isDate(payload: any): payload is Date;
+export declare function isDate(payload: unknown): payload is Date;
 /**
  * Returns whether the payload is a Blob
  *
  * @param {*} payload
  * @returns {payload is Blob}
  */
-export declare function isBlob(payload: any): payload is Blob;
+export declare function isBlob(payload: unknown): payload is Blob;
 /**
  * Returns whether the payload is a File
  *
  * @param {*} payload
  * @returns {payload is File}
  */
-export declare function isFile(payload: any): payload is File;
+export declare function isFile(payload: unknown): payload is File;
 /**
  * Returns whether the payload is a Promise
  *
  * @param {*} payload
  * @returns {payload is Promise}
  */
-export declare function isPromise(payload: any): payload is Promise<any>;
+export declare function isPromise(payload: unknown): payload is Promise<unknown>;
 /**
  * Returns whether the payload is an Error
  *
  * @param {*} payload
  * @returns {payload is Error}
  */
-export declare function isError(payload: any): payload is Error;
+export declare function isError(payload: unknown): payload is Error;
 /**
  * Returns whether the payload is a primitive type (eg. Boolean | Null | Undefined | Number | String | Symbol)
  *
  * @param {*} payload
  * @returns {(payload is boolean | null | undefined | number | string | symbol)}
  */
-export declare function isPrimitive(payload: any): payload is boolean | null | undefined | number | string | symbol;
+export declare function isPrimitive(payload: unknown): payload is boolean | null | undefined | number | string | symbol;
 /**
  * Returns true whether the payload is null or undefined
  *
  * @param {*} payload
  * @returns {(payload is null | undefined)}
  */
-export declare function isNullOrUndefined(payload: any): payload is null | undefined;
+export declare function isNullOrUndefined(payload: unknown): payload is null | undefined;
 /**
  * Does a generic check to check that the given payload is of a given type.
  * In cases like Number, it will return true for NaN as NaN is a Number (thanks javascript!);
@@ -209,4 +209,4 @@ export declare function isNullOrUndefined(payload: any): payload is null | undef
  * @throws {TypeError} Will throw type error if type is an invalid type
  * @returns {payload is T}
  */
-export declare function isType<T extends Function>(payload: any, type: T): payload is T;
+export declare function isType<T extends Function>(payload: unknown, type: T): payload is T;


### PR DESCRIPTION
Change `any` to `unknown`, as `unknown` is far more type safe than `any`.

This will force users to use type assertion like `someValue as string` or do further type check like `someValue is string`.

This change will make the codebase using this library more type aware syntax wise, and also visually.

This is definitely a breaking change.

But I suppose most users are using this library to be more type aware of their codes anyway.

Should be a move in the right direction.