### PR TITLE
fix: update isPlainObject method to account for 'constructor' key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,8 @@ export function isNull(payload: any): payload is null {
  */
 export function isPlainObject(payload: any): payload is PlainObject {
   if (getType(payload) !== 'Object') return false
-  return payload.constructor === Object && Object.getPrototypeOf(payload) === Object.prototype
+  const prototype = Object.getPrototypeOf(payload)
+  return prototype.constructor === Object && prototype === Object.prototype
 }
 
 /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -307,8 +307,10 @@ test('isObject vs isAnyObject', () => {
   // plain object
   expect(isObject({})).toEqual(true)
   expect(isObject(new Object())).toEqual(true)
+  expect(isObject({ constructor: '123' })).toEqual(true)
   expect(isPlainObject({})).toEqual(true)
   expect(isPlainObject(new Object())).toEqual(true)
+  expect(isPlainObject({ constructor: '123' })).toEqual(true)
   // classes & prototypes
   expect(isObject(myClass)).toEqual(false)
   expect(isObject(myClass2)).toEqual(false)


### PR DESCRIPTION
`isPlainObject` method should return `true` even when the plain object has its own `constructor` property.