### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+concurrency:
+  group: publish
+  cancel-in-progress: true
+permissions: write-all
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          cache: npm
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
ref #40 

This PR would...
- [x] Add a workflow that runs on each  published release (and pre-release) to publish that current state of the repo to npm using `npm publish`

1. Make sure that when you create releases you have already bumped the version in package.json!
2. Make sure you add an NPM_TOKEN secret with publish permissions!

It might also be worth considering using https://github.com/github/gitignore/blob/main/Node.gitignore and generating `dist/` in a `prepack` hook in CI so that the dist JS isn't stored and versioned in Git. 🤔