### PR TITLE
Add docs website

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
           cache: npm
       - run: npm ci
       - uses: actions/configure-pages@v3
-      - run: npm run build-docs
+      - run: npm run build:docs
       - uses: actions/upload-pages-artifact@v1
         with:
           path: docs/dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+concurrency:
+  group: publish
+  cancel-in-progress: true
+permissions: write-all
+jobs:
+  publish-docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-pages.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          cache: npm
+      - run: npm ci
+      - uses: actions/configure-pages@v3
+      - run: npm run build-docs
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/dist
+      - id: deploy-pages
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,22 +1,22 @@
 name: Test
 on:
   push:
-    branches: [$default-branch]
+    branches: 'dev'
     paths:
       - src/**
       - test/**
-      - "*.js"
-      - "*.ts"
-      - "*.json"
+      - '*.js'
+      - '*.ts'
+      - '*.json'
       - .github/workflows/test.yml
   pull_request:
-    branches: [$default-branch]
+    branches: 'dev'
     paths:
       - src/**
       - test/**
-      - "*.js"
-      - "*.ts"
-      - "*.json"
+      - '*.js'
+      - '*.ts'
+      - '*.json'
       - .github/workflows/test.yml
 concurrency:
   group: test-${{ github.ref }}
@@ -25,7 +25,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: ["16", "18", "20"]
+        node-version: ['16', '18', '20']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+docs/dist
 node_modules/
 .cache
 .rpt2_cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "rollup": "^3.22.0",
         "rollup-plugin-dts": "^5.3.0",
         "rollup-plugin-esbuild": "^5.0.0",
+        "typedoc": "^0.24.7",
         "typescript": "^5.0.4",
         "vitest": "^0.31.1"
       },
@@ -1188,6 +1189,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+      "dev": true
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -4530,6 +4537,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/magic-string": {
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
@@ -4582,6 +4595,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/md5-hex": {
@@ -6401,6 +6426,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.2.tgz",
+      "integrity": "sha512-ltSZlSLOuSY0M0Y75KA+ieRaZ0Trf5Wl3gutE7jzLuIcWxLp5i/uEnLoQWNvgKXQ5OMpGkJnVMRLAuzjc0LJ2A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -6809,6 +6846,51 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.24.7",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.7.tgz",
+      "integrity": "sha512-zzfKDFIZADA+XRIp2rMzLe9xZ6pt12yQOhCr7cD7/PBTjhPmMyMvGrkZ2lPNJitg3Hj1SeiYFNzCsSDrlpxpKw==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
+        "shiki": "^0.14.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
@@ -7150,6 +7232,18 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "node_modules/well-known-symbols": {
       "version": "2.0.0",
@@ -8071,6 +8165,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -10558,6 +10658,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "magic-string": {
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
@@ -10597,6 +10703,12 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
       "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+      "dev": true
+    },
+    "marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true
     },
     "md5-hex": {
@@ -11889,6 +12001,18 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shiki": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.2.tgz",
+      "integrity": "sha512-ltSZlSLOuSY0M0Y75KA+ieRaZ0Trf5Wl3gutE7jzLuIcWxLp5i/uEnLoQWNvgKXQ5OMpGkJnVMRLAuzjc0LJ2A==",
+      "dev": true,
+      "requires": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -12202,6 +12326,38 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.24.7",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.7.tgz",
+      "integrity": "sha512-zzfKDFIZADA+XRIp2rMzLe9xZ6pt12yQOhCr7cD7/PBTjhPmMyMvGrkZ2lPNJitg3Hj1SeiYFNzCsSDrlpxpKw==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
+        "shiki": "^0.14.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+          "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "typescript": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
@@ -12406,6 +12562,18 @@
         "vite-node": "0.31.1",
         "why-is-node-running": "^2.2.2"
       }
+    },
+    "vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "well-known-symbols": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "vitest run",
     "lint": "tsc --noEmit && eslint ./src --ext .ts",
     "build": "rollup -c ./rollup.config.js",
+    "build:docs": "typedoc",
     "release": "npm run lint && del dist && npm run build && np"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "rollup-plugin-dts": "^5.3.0",
     "rollup-plugin-esbuild": "^5.0.0",
     "typescript": "^5.0.4",
-    "vitest": "^0.31.1"
+    "vitest": "^0.31.1",
+    "typedoc": "^0.24.7"
   },
   "ava": {
     "extensions": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -359,21 +359,65 @@ export function isPrimitive(
  */
 export const isNullOrUndefined = isOneOf(isNull, isUndefined)
 
+/**
+ * A factory function that creates a function to check if the payload is one of the given types.
+ * @example
+ * import { isOneOf, isNull, isUndefined } from 'is-what'
+ *
+ * const isNullOrUndefined = isOneOf(isNull, isUndefined)
+ *
+ * isNullOrUndefined(null) // true
+ * isNullOrUndefined(undefined) // true
+ * isNullOrUndefined(123) // false
+ */
 export function isOneOf<A, B extends A, C extends A>(
   a: TypeGuard<A, B>,
   b: TypeGuard<A, C>
 ): TypeGuard<A, B | C>
+/**
+ * A factory function that creates a function to check if the payload is one of the given types.
+ * @example
+ * import { isOneOf, isNull, isUndefined } from 'is-what'
+ *
+ * const isNullOrUndefined = isOneOf(isNull, isUndefined)
+ *
+ * isNullOrUndefined(null) // true
+ * isNullOrUndefined(undefined) // true
+ * isNullOrUndefined(123) // false
+ */
 export function isOneOf<A, B extends A, C extends A, D extends A>(
   a: TypeGuard<A, B>,
   b: TypeGuard<A, C>,
   c: TypeGuard<A, D>
 ): TypeGuard<A, B | C | D>
+/**
+ * A factory function that creates a function to check if the payload is one of the given types.
+ * @example
+ * import { isOneOf, isNull, isUndefined } from 'is-what'
+ *
+ * const isNullOrUndefined = isOneOf(isNull, isUndefined)
+ *
+ * isNullOrUndefined(null) // true
+ * isNullOrUndefined(undefined) // true
+ * isNullOrUndefined(123) // false
+ */
 export function isOneOf<A, B extends A, C extends A, D extends A, E extends A>(
   a: TypeGuard<A, B>,
   b: TypeGuard<A, C>,
   c: TypeGuard<A, D>,
   d: TypeGuard<A, E>
 ): TypeGuard<A, B | C | D | E>
+/**
+ * A factory function that creates a function to check if the payload is one of the given types.
+ * @example
+ * import { isOneOf, isNull, isUndefined } from 'is-what'
+ *
+ * const isNullOrUndefined = isOneOf(isNull, isUndefined)
+ *
+ * isNullOrUndefined(null) // true
+ * isNullOrUndefined(undefined) // true
+ * isNullOrUndefined(123) // false
+ */
 export function isOneOf<A, B extends A, C extends A, D extends A, E extends A, F extends A>(
   a: TypeGuard<A, B>,
   b: TypeGuard<A, C>,
@@ -381,6 +425,17 @@ export function isOneOf<A, B extends A, C extends A, D extends A, E extends A, F
   d: TypeGuard<A, E>,
   e: TypeGuard<A, F>
 ): TypeGuard<A, B | C | D | E | F>
+/**
+ * A factory function that creates a function to check if the payload is one of the given types.
+ * @example
+ * import { isOneOf, isNull, isUndefined } from 'is-what'
+ *
+ * const isNullOrUndefined = isOneOf(isNull, isUndefined)
+ *
+ * isNullOrUndefined(null) // true
+ * isNullOrUndefined(undefined) // true
+ * isNullOrUndefined(123) // false
+ */
 export function isOneOf(
   a: AnyFunction,
   b: AnyFunction,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,10 @@
     "target": "es2019",
     "useDefineForClassFields": true
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*", "test/**/*"],
+  "typedocOptions": {
+    "entryPoints": ["src/index.ts"],
+    "out": "docs/dist",
+    "skipErrorChecking": true
+  }
 }


### PR DESCRIPTION
This PR would...
- [x] Add TypeDoc as a dev dep https://typedoc.org/
- [x] Auto-generate a website and deploy it to GitHub Pages using GitHub Actions **on each Release**
- [x] Change package-lock.json
- [x] Add typedoc config in tsconfig.json
- [x] Create a website that can go on Google

Note that you'd need to make sure that GitHub Pages in Settings tab is set to receive from GitHub Actions. By default it's set to OFF.

![image](https://github.com/mesqueeb/is-what/assets/61068799/839ac729-e01d-4740-ad9d-2e01a90ee163)

You can view the website yourself on GitHub Codespaces via the "Code" dropdown on this PR, then run:

```sh
npm run build-docs
python -m http.server -d docs/dist
```

You could change:
- the `npm run build-docs` script to be whatever name you want
- the out folder from `docs/dist` to `_site` or `.typedoc` or whatever

I'd **recommend** adding more extensive JSDoc blocks with `@example` and other documentation stuff to each of the functions. This would help the doc gen and the tooltip hovers in VSCode and other LSP editors. Here's what `isPlainObject()` looks like right now:

![image](https://github.com/mesqueeb/is-what/assets/61068799/7ef0a88f-699d-4c20-b2b5-4b66342013b2)

Note that right now "is-what" is _terrible_ for Google SEO since even refinements like "is-what npm" or "is-what github" all are like "What is GitHub?" and "What is npm? A quick intro." instead of this package. 🤣 I think that a website would be a good idea to make a presence for Googlers and also provide valuable documentation overview that is **generated from code** and doesn't need to be custom-made in the readme. Specifically, **examples are CRUCIAL**.