### PR TITLE
Remove user-custom VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-  "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.tabSize": 2, // make sure this is the same as .prettierrc
-  "editor.insertSpaces": true,
-  "files.insertFinalNewline": true,
-  "files.trimFinalNewlines": true,
-  "files.trimTrailingWhitespace": true
-}


### PR DESCRIPTION
This PR would...
- [x] Remove the .vscode/settings.json

It's _generally_ recommended that formatting stuff like formatOnSave and other such rules go in your own custom user-specific VS Code settings. In general, I think that .vscode/settings.json is more for project-specific patches on things like file extension association, extension customization (like enabling "Deno mode" for tsc checking) or other workspace-specific things.

This also helps encourage better formatting scripts like running `prettier -w .` or similar to _actually enforce these settings_ for **all users** even those using Neovim or JetBrains or whatever.

Also on a popularity note, .vscode/settings.json files are _relatively_ rare, especially in comparison to prettierrc files! [37k](https://github.com/search?q=path%3A%2F.vscode%2Fsettings&type=code) vs [101k](https://github.com/search?q=path%3A%2F.prettierrc*&type=code) and that's just the js prettier ecosystem! 😱

If there's a genuine workflow improvement or reason for this file to be here, then I'd love to hear it and add that explanation to the readme! ❤️ Documentation about code workflow stuff is a good thing 👍