### PR TITLE
Remove prettier config

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,17 +112,5 @@
       "tree-shaking/no-side-effects-in-initialization": "error",
       "@typescript-eslint/ban-ts-comment": "off"
     }
-  },
-  "prettier": {
-    "printWidth": 100,
-    "tabWidth": 2,
-    "singleQuote": true,
-    "trailingComma": "es5",
-    "semi": false,
-    "bracketSpacing": true,
-    "quoteProps": "consistent",
-    "plugins": [
-      "prettier-plugin-jsdoc"
-    ]
   }
 }


### PR DESCRIPTION
Going based on this sentiment:

> So I just chose, there's nothing you can't do with named exports, so why not only use named exports. It's all about reducing options and streamlining, unifying, calming the mind. ;)
https://github.com/mesqueeb/is-what/issues/60#issuecomment-1579424402

Reducing the amount of customization seems like a good idea. **Prettier themselves even recommend against modifying the config!** 😊

> By far the biggest reason for adopting Prettier is to stop all the ongoing debates over styles.
https://prettier.io/docs/en/option-philosophy.html

_Sidenote: Prettier auto-includes any `prettier-plugin-*` packages, so you don't need the `plugins: []` option at all_