### PR TITLE
Tweak workflows

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -1,7 +1,7 @@
 name: Preview docs
 on:
   pull_request:
-    branches: production
+    branches: 'main'
     paths:
       - docs/**
       - '*rc'
@@ -10,7 +10,7 @@ on:
       - '*.lock'
       - .github/workflows/preview-docs.yml
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 jobs:
   preview-docs:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,6 +20,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - if: github.event.release.prerelease
-        run: npm publish --tag next --access public
+        run: npm publish --tag beta --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -5,7 +5,8 @@ on:
   workflow_dispatch:
 concurrency: ${{ github.workflow }}
 jobs:
-  publish-npm:
+  publish-npm-release:
+    if: '!github.event.release.prerelease'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -15,11 +16,23 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm test
-      - if: '!github.event.release.prerelease'
-        run: npm publish --access public
+      - run: |
+          npm publish
+          npm dist-tag add "$(npm view . name)@$(npm view . version)" next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-      - if: github.event.release.prerelease
-        run: npm publish --tag beta --access public
+  publish-npm-prerelease:
+    if: github.event.release.prerelease
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          cache: npm
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: |
+          npm publish --tag beta
+          npm dist-tag add "$(npm view . name)@$(npm view . version)" next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,9 +3,7 @@ on:
   release:
     types: [published, prereleased]
   workflow_dispatch:
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
+concurrency: ${{ github.workflow }}
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
@@ -17,12 +15,11 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm test
-      - name: Publish to npm
-        run: |
-          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
-            npm publish --tag next --access public
-          else
-            npm publish --access public
-          fi
+      - if: '!github.event.release.prerelease'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      - if: github.event.release.prerelease
+        run: npm publish --tag next --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,7 +1,7 @@
 name: Publish npm
 on:
   release:
-    types: [published, prereleased]
+    types: published
   workflow_dispatch:
 concurrency: ${{ github.workflow }}
 jobs:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -5,8 +5,7 @@ on:
   workflow_dispatch:
 concurrency: ${{ github.workflow }}
 jobs:
-  publish-npm-release:
-    if: '!github.event.release.prerelease'
+  publish-npm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,23 +15,10 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm test
-      - run: |
-          npm publish
-          npm dist-tag add "$(npm view . name)@$(npm view . version)" next
+      - run: npm publish --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-  publish-npm-prerelease:
-    if: github.event.release.prerelease
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          cache: npm
-          registry-url: https://registry.npmjs.org/
-      - run: npm ci
-      - run: |
-          npm publish --tag beta
-          npm dist-tag add "$(npm view . name)@$(npm view . version)" next
+      - if: '!github.event.release.prerelease'
+        run: npm dist-tag add "$(npm view . name)@$(npm view . version)" latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 on:
   push:
-    branches: 'production'
+    branches: 'main'
     paths:
       - src/**
       - test/**
@@ -10,7 +10,7 @@ on:
       - '*.json'
       - .github/workflows/test.yml
   pull_request:
-    branches: 'production'
+    branches: 'main'
     paths:
       - src/**
       - test/**
@@ -19,7 +19,7 @@ on:
       - '*.json'
       - .github/workflows/test.yml
 concurrency:
-  group: test-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 jobs:
   test:


### PR DESCRIPTION
🛑 THIS SHOULD BE MERGED [IFF](https://en.wikipedia.org/wiki/If_and_only_if) 'production' is renamed to 'main'

This PR would...
- [x] Rename production to main in all main-related and PR-related workflows
- [x] _Always_ update the `@next` tag, even when it's a regular release.
- [x] Remove the redundant release prereleased trigger
- [x] Use github actions `if: ...` step-level statements instead of bash `if [[ ]]` commands

The npm convention appears to be to **continuously update the `@next` target so that it's _at or ahead of `@latest`_** so I've done that.

![image](https://github.com/mesqueeb/is-what/assets/61068799/bf5be252-3018-4168-8728-b52a01cc5427)

![image](https://github.com/mesqueeb/is-what/assets/61068799/710010f5-3ea0-43e0-8a4a-6f4a7218f82c)

I've switched it around to align with that convention.
Here's more discussion on that next vs beta stuff: https://github.com/semantic-release/semantic-release/discussions/2336

As for the prerelease trigger, that's redundant. The `published` type works for ALL published releases, including prereleases. (this is a test repo, hence the failed publish)

![image](https://github.com/mesqueeb/is-what/assets/61068799/40f4d542-021c-4b22-93fc-dc3f70cfa380)
![image](https://github.com/mesqueeb/is-what/assets/61068799/09ed8f2d-e80a-4a0b-91ff-5f68e98624a7)
![image](https://github.com/mesqueeb/is-what/assets/61068799/ceab48be-a590-406c-86d8-67fb6631db4b)
