### PR TITLE
Move typedocOptions to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,5 +124,10 @@
     "plugins": [
       "prettier-plugin-jsdoc"
     ]
+  },
+  "typedocOptions": {
+    "entryPoints": ["src/index.ts"],
+    "out": "docs/dist",
+    "skipErrorChecking": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,10 +17,5 @@
     "target": "es2019",
     "useDefineForClassFields": true
   },
-  "include": ["src/**/*", "test/**/*"],
-  "typedocOptions": {
-    "entryPoints": ["src/index.ts"],
-    "out": "docs/dist",
-    "skipErrorChecking": true
-  }
+  "include": ["src/**/*", "test/**/*"]
 }


### PR DESCRIPTION
<!-- Thanks for contributing! ❤️ -->

This would be a good idea because: everything else is in package.json already, so you might as well make typedocOptions there too